### PR TITLE
iOS 14 Widget reliability improvements

### DIFF
--- a/LockdownFirewallWidget/LockdownFirewallWidget.swift
+++ b/LockdownFirewallWidget/LockdownFirewallWidget.swift
@@ -15,7 +15,7 @@ struct FirewallProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (FirewallEntry) -> ()) {
-        let entry = FirewallEntry(date: Date(), size: context.displaySize, isFirewallEnabled: getUserWantsFirewallEnabled(), dayMetricsString: getDayMetricsString(commas: true))
+        let entry = FirewallEntry(date: Date(), size: context.displaySize, isFirewallEnabled: LatestKnowledge.isFirewallEnabled, dayMetricsString: getDayMetricsString(commas: true))
         completion(entry)
     }
 
@@ -23,7 +23,7 @@ struct FirewallProvider: TimelineProvider {
         var entries: [FirewallEntry] = []
         
         let currentDate = Date()
-        let entry = FirewallEntry(date: Date(), size: context.displaySize, isFirewallEnabled: getUserWantsFirewallEnabled(), dayMetricsString: getDayMetricsString(commas: true))
+        let entry = FirewallEntry(date: Date(), size: context.displaySize, isFirewallEnabled: LatestKnowledge.isFirewallEnabled, dayMetricsString: getDayMetricsString(commas: true))
         entries.append(entry)
 
         let timeline = Timeline(
@@ -92,7 +92,7 @@ struct VPNProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (VPNEntry) -> ()) {
-        let entry = VPNEntry(date: Date(), size: context.displaySize, isVPNEnabled: getUserWantsVPNEnabled(), vpnRegion: getSavedVPNRegion())
+        let entry = VPNEntry(date: Date(), size: context.displaySize, isVPNEnabled: LatestKnowledge.isVPNEnabled, vpnRegion: getSavedVPNRegion())
         completion(entry)
     }
 
@@ -100,7 +100,7 @@ struct VPNProvider: TimelineProvider {
         var entries: [VPNEntry] = []
         
         let currentDate = Date()
-        let entry = VPNEntry(date: Date(), size: context.displaySize, isVPNEnabled: getUserWantsVPNEnabled(), vpnRegion: getSavedVPNRegion())
+        let entry = VPNEntry(date: Date(), size: context.displaySize, isVPNEnabled: LatestKnowledge.isVPNEnabled, vpnRegion: getSavedVPNRegion())
         entries.append(entry)
 
         let timeline = Timeline(

--- a/LockdowniOS/AppDelegate.swift
+++ b/LockdowniOS/AppDelegate.swift
@@ -17,6 +17,7 @@ import CocoaLumberjackSwift
 import PopupDialog
 import PromiseKit
 import UserNotifications
+import WidgetKit
 
 let fileLogger: DDFileLogger = DDFileLogger()
 
@@ -171,6 +172,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func applicationDidBecomeActive(_ application: UIApplication) {
         updateMetrics(.resetIfNeeded, rescheduleNotifications: .always)
+    }
+    
+    func applicationWillResignActive(_ application: UIApplication) {
+        if #available(iOS 14.0, *) {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
     }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/LockdowniOS/HomeViewController.swift
+++ b/LockdowniOS/HomeViewController.swift
@@ -747,6 +747,14 @@ class HomeViewController: BaseViewController, AwesomeSpotlightViewDelegate, Load
     
     func updateFirewallButtonWithStatus(status: NEVPNStatus) {
         DDLogInfo("UpdateFirewallButton")
+        switch status {
+        case .connected:
+            LatestKnowledge.isFirewallEnabled = true
+        case .disconnected:
+            LatestKnowledge.isFirewallEnabled = false
+        default:
+            break
+        }
         updateToggleButtonWithStatus(lastStatus: lastFirewallStatus,
                                      newStatus: status,
                                      activeLabel: firewallActive,
@@ -885,6 +893,14 @@ class HomeViewController: BaseViewController, AwesomeSpotlightViewDelegate, Load
     
     func updateVPNButtonWithStatus(status: NEVPNStatus) {
         DDLogInfo("UpdateVPNButton")
+        switch status {
+        case .connected:
+            LatestKnowledge.isVPNEnabled = true
+        case .disconnected:
+            LatestKnowledge.isVPNEnabled = false
+        default:
+            break
+        }
         updateToggleButtonWithStatus(lastStatus: lastVPNStatus,
                                      newStatus: status,
                                      activeLabel: vpnActive,

--- a/LockdowniOS/VPNController.swift
+++ b/LockdowniOS/VPNController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import NetworkExtension
 import CocoaLumberjackSwift
+import WidgetKit
 
 let kVPNLocalizedDescription = "Lockdown VPN"
 
@@ -38,6 +39,9 @@ class VPNController: NSObject {
     func setEnabled(_ enabled: Bool, completion: @escaping (_ error: Error?) -> Void = {_ in }) {
         DDLogInfo("VPNController set enabled: \(enabled)")
         setUserWantsVPNEnabled(enabled)
+        if #available(iOSApplicationExtension 14.0, iOS 14.0, *) {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
         if (enabled) {
             setUpAndEnableVPN { error in
                 completion(error)

--- a/UserDefaults.swift
+++ b/UserDefaults.swift
@@ -13,6 +13,31 @@ let defaults = UserDefaults(suiteName: "group.com.confirmed")!
 let kUserWantsFirewallEnabled = "user_wants_firewall_enabled"
 let kUserWantsVPNEnabled = "user_wants_vpn_enabled"
 
+enum LatestKnowledge {
+    
+    private static let kLatestKnowledgeIsFirewallEnabled = "kLatestKnowledgeIsFirewallEnabled"
+    private static let kLatestKnowledgeIsVPNEnabled = "kLatestKnowledgeIsVPNEnabled"
+    
+    static var isFirewallEnabled: Bool {
+        get {
+            return defaults.bool(forKey: kLatestKnowledgeIsFirewallEnabled)
+        }
+        set {
+            defaults.setValue(newValue, forKey: kLatestKnowledgeIsFirewallEnabled)
+        }
+    }
+    
+    static var isVPNEnabled: Bool {
+        get {
+            return defaults.bool(forKey: kLatestKnowledgeIsVPNEnabled)
+        }
+        set {
+            defaults.setValue(newValue, forKey: kLatestKnowledgeIsVPNEnabled)
+        }
+    }
+    
+}
+
 func setUserWantsFirewallEnabled(_ enabled: Bool) {
     defaults.set(enabled, forKey: kUserWantsFirewallEnabled)
 }


### PR DESCRIPTION
Improves the reliability of the widget by not using `getUserWantsFirewallEnabled` to determine if the state of the widget should be on or off, but rather using values synchronised with the buttons in the app itself.