### PR TITLE
Fixes related to tabbar update

### DIFF
--- a/Client.swift
+++ b/Client.swift
@@ -264,7 +264,7 @@ class Client {
     private static func getReceipt(forceRefresh: Bool) -> Promise<String> {
         DDLogInfo("fetch and set latest receipt")
         return Promise { seal in
-            SwiftyStoreKit.fetchReceipt(forceRefresh: forceRefresh) { result in
+            SwiftyStoreKit.fetchReceipt(forceRefresh: true) { result in
                 switch result {
                 case .success(let receiptData):
                     let receipt = receiptData.base64EncodedString(options: [])

--- a/LockdowniOS.xcodeproj/project.pbxproj
+++ b/LockdowniOS.xcodeproj/project.pbxproj
@@ -2202,7 +2202,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2234,7 +2234,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2314,7 +2314,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = LockdownFirewallWidget/Info.plist;
@@ -2344,7 +2344,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = LockdownFirewallWidget/Info.plist;
@@ -2486,7 +2486,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2521,7 +2521,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2562,7 +2562,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2600,7 +2600,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2631,7 +2631,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Lockdown Blocker/Info.plist";
@@ -2657,7 +2657,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Lockdown Blocker/Info.plist";
@@ -2685,7 +2685,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2717,7 +2717,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = V8J3Z26F6Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/LockdowniOS.xcodeproj/xcshareddata/xcschemes/Lockdown.xcscheme
+++ b/LockdowniOS.xcodeproj/xcshareddata/xcschemes/Lockdown.xcscheme
@@ -86,13 +86,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/LockdowniOS/Account/EmailSignInViewController.swift
+++ b/LockdowniOS/Account/EmailSignInViewController.swift
@@ -15,12 +15,6 @@ import CocoaLumberjackSwift
 
 class EmailSignInViewController: BaseViewController, UITextFieldDelegate, Loadable {
     
-    struct Delegate {
-        var accountStateDidChange: () -> () = { }
-    }
-    
-    var delegate = Delegate()
-    
     @IBOutlet weak var emailField: UITextField!
     @IBOutlet weak var passwordField: UITextField!
     
@@ -70,9 +64,9 @@ class EmailSignInViewController: BaseViewController, UITextFieldDelegate, Loadab
             try setAPICredentials(email: email, password: password)
             setAPICredentialsConfirmed(confirmed: true)
             self.hideLoadingView()
-            self.delegate.accountStateDidChange()
+            NotificationCenter.default.post(name: AccountUI.accountStateDidChange, object: self)
             self.showPopupDialog(title: "Success! 🎉", message: "You've successfully signed in.", acceptButton: "Okay") {
-                self.dismiss(animated: true, completion: {
+                self.presentingViewController?.dismiss(animated: true, completion: {
                     // logged in and confirmed - update this email with the receipt and refresh VPN credentials
                     firstly { () -> Promise<SubscriptionEvent> in
                         try Client.subscriptionEvent()

--- a/LockdowniOS/Account/EmailSignUpViewController.swift
+++ b/LockdowniOS/Account/EmailSignUpViewController.swift
@@ -15,7 +15,6 @@ import PromiseKit
 class EmailSignUpViewController: BaseViewController, UITextFieldDelegate, Loadable {
     
     struct Delegate {
-        var accountStateDidChange: () -> () = { }
         var showSignIn: () -> () = { }
     }
     
@@ -120,11 +119,11 @@ class EmailSignUpViewController: BaseViewController, UITextFieldDelegate, Loadab
                         popup.addButtons([
                            DefaultButton(title: NSLocalizedString("Okay", comment: ""), dismissOnTap: true) {
                                 self.hideLoadingView()
-                                self.dismiss(animated: true, completion: nil)
+                                self.presentingViewController?.dismiss(animated: true, completion: nil)
                            }
                         ])
                         self.present(popup, animated: true, completion: nil)
-                        self.delegate.accountStateDidChange()
+                        NotificationCenter.default.post(name: AccountUI.accountStateDidChange, object: self)
                     }
                     catch {
                         self.showPopupDialog(title: "Error Saving Credentials", message: "Couldn't save credentials to local keychain. Please report this error to team@lockdownprivacy.com.", acceptButton: "Okay")

--- a/LockdowniOS/AccountUI.swift
+++ b/LockdowniOS/AccountUI.swift
@@ -10,23 +10,23 @@ import UIKit
 
 enum AccountUI {
     
-    static func presentCreateAccount(on vc: UIViewController, completion: @escaping () -> () = { }) {
+    static let accountStateDidChange = Notification.Name("AccountUIAccountStateDidChangeNotification")
+    
+    static func presentCreateAccount(on vc: UIViewController) {
         let storyboard = UIStoryboard.main
         let viewController = storyboard.instantiateViewController(withIdentifier: "emailSignUpViewController") as! EmailSignUpViewController
         viewController.delegate.showSignIn = { [weak vc] in
             if let strongVC = vc {
-                AccountUI.presentSignInToAccount(on: strongVC, completion: completion)
+                AccountUI.presentSignInToAccount(on: strongVC)
             }
         }
-        viewController.delegate.accountStateDidChange = completion
         
         vc.present(viewController, animated: true, completion: nil)
     }
     
-    static func presentSignInToAccount(on vc: UIViewController, completion: @escaping () -> () = { }) {
+    static func presentSignInToAccount(on vc: UIViewController) {
         let storyboard = UIStoryboard.main
         let viewController = storyboard.instantiateViewController(withIdentifier: "emailSignInViewController") as! EmailSignInViewController
-        viewController.delegate.accountStateDidChange = completion
         
         vc.present(viewController, animated: true, completion: nil)
     }

--- a/LockdowniOS/AccountVC.swift
+++ b/LockdowniOS/AccountVC.swift
@@ -28,17 +28,23 @@ final class AccountViewController: BaseViewController, Loadable {
             tableView.contentInset.top += 12
             tableView.tableFooterView = UIView()
             
+            tableView.clear()
             createTable()
+        }
+        
+        do {
+            NotificationCenter.default.addObserver(self, selector: #selector(accountStateDidChange), name: AccountUI.accountStateDidChange, object: nil)
         }
     }
     
+    @objc
+    func accountStateDidChange() {
+        assert(Thread.isMainThread)
+        self.reloadTable()
+    }
+    
     func reloadTable() {
-        // always reload when called
-//        guard isViewLoaded else {
-//            return
-//        }
-        
-        tableView.rows = []
+        tableView.clear()
         createTable()
         tableView.reloadData()
     }
@@ -49,9 +55,9 @@ final class AccountViewController: BaseViewController, Loadable {
         var title = "⚠️ Not Signed In"
         var message: String? = "Sign up below to unlock benefits of a Lockdown account."
         var firstButton = DefaultCell(title: NSLocalizedString("Sign Up  |  Sign In", comment: ""), height: buttonHeight, dismissOnTap: true) {
-            AccountUI.presentCreateAccount(on: self) { [weak self] in
-                self?.reloadTable()
-            }
+            // AccountViewController will update itself by observing
+            // AccountUI.accountStateDidChange notification
+            AccountUI.presentCreateAccount(on: self)
         }
         firstButton.backgroundView = UIView()
         firstButton.backgroundView?.backgroundColor = UIColor.tunnelsBlue

--- a/LockdowniOS/AccountVC.swift
+++ b/LockdowniOS/AccountVC.swift
@@ -33,9 +33,10 @@ final class AccountViewController: BaseViewController, Loadable {
     }
     
     func reloadTable() {
-        guard isViewLoaded else {
-            return
-        }
+        // always reload when called
+//        guard isViewLoaded else {
+//            return
+//        }
         
         tableView.rows = []
         createTable()
@@ -193,7 +194,7 @@ final class AccountViewController: BaseViewController, Loadable {
         }
         
         let upgradeButton = DefaultButtonCell(title: "Loading Plan", height: buttonHeight, dismissOnTap: true) {
-            self.performSegue(withIdentifier: "showUpgradePlan", sender: self)
+            self.performSegue(withIdentifier: "showUpgradePlanAccount", sender: self)
         }
         upgradeButton.startActivityIndicator()
         upgradeButton.button.isEnabled = false
@@ -239,14 +240,22 @@ final class AccountViewController: BaseViewController, Loadable {
                     upgradeButton.button.setTitleColor(UIColor.white, for: UIControl.State())
                     upgradeButton.button.setTitle("View Upgrade Options", for: UIControl.State())
                 default:
-                    upgradeButton.button.isEnabled = false
-                    upgradeButton.selectionStyle = .none
-                    upgradeButton.button.setTitle("Cannot load your plan", for: UIControl.State())
+                    upgradeButton.button.isEnabled = true
+                    upgradeButton.selectionStyle = .default
+                    upgradeButton.button.setTitleColor(UIColor.systemRed, for: UIControl.State())
+                    upgradeButton.button.setTitle("Error Loading Plan: Retry", for: UIControl.State())
+                    upgradeButton.onSelect {
+                        self.reloadTable()
+                    }
                 }
             } else {
-                upgradeButton.button.isEnabled = false
-                upgradeButton.selectionStyle = .none
-                upgradeButton.button.setTitle("Cannot load your plan", for: UIControl.State())
+                upgradeButton.button.isEnabled = true
+                upgradeButton.selectionStyle = .default
+                upgradeButton.button.setTitleColor(UIColor.systemRed, for: UIControl.State())
+                upgradeButton.button.setTitle("Error Loading Plan: Retry", for: UIControl.State())
+                upgradeButton.onSelect {
+                    self.reloadTable()
+                }
             }
         }
         
@@ -346,6 +355,17 @@ final class AccountViewController: BaseViewController, Loadable {
         case "showWhatIsVPN":
             if let vc = segue.destination as? WhatIsVpnViewController {
                 vc.parentVC = (tabBarController as? MainTabBarController)?.homeViewController
+            }
+        case "showUpgradePlanAccount":
+            if let vc = segue.destination as? SignupViewController {
+                vc.parentVC = self
+                if activePlans.isEmpty {
+                    vc.mode = .newSubscription
+                    vc.enableVPNAfterSubscribe = true
+                } else {
+                    vc.mode = .upgrade(active: activePlans)
+                    vc.enableVPNAfterSubscribe = true
+                }
             }
         default:
             break

--- a/LockdowniOS/AppDelegate.swift
+++ b/LockdowniOS/AppDelegate.swift
@@ -489,7 +489,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 ])
                 self.getCurrentViewController()?.present(popup, animated: true, completion: nil)
                 DispatchQueue.main.async {
-                    (self.window?.rootViewController as? MainTabBarController)?.accountViewController.reloadTable()
+                    NotificationCenter.default.post(name: AccountUI.accountStateDidChange, object: self)
                 }
             }
             .catch { error in

--- a/LockdowniOS/Base.lproj/Main.storyboard
+++ b/LockdowniOS/Base.lproj/Main.storyboard
@@ -45,16 +45,16 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hio-Xi-kNY">
-                                <rect key="frame" x="32" y="329.66666666666669" width="350" height="56.666666666666686"/>
+                                <rect key="frame" x="32" y="330.66666666666669" width="350" height="54.666666666666686"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Block Log Disabled" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Mg-Xn-BmP">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="25.666666666666668"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="24.666666666666668"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="21"/>
                                         <color key="textColor" red="0.72156862749999995" green="0.72156862749999995" blue="0.72336632010000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j7V-kr-ymm">
-                                        <rect key="frame" x="0.0" y="25.666666666666629" width="350" height="31"/>
+                                        <rect key="frame" x="0.0" y="24.666666666666629" width="350" height="30"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="15"/>
                                         <state key="normal" title="Enable Block Log">
                                             <color key="titleColor" name="Confirmed Blue"/>
@@ -69,7 +69,7 @@
                                 </constraints>
                             </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="I2D-RD-nwm">
-                                <rect key="frame" x="0.0" y="168" width="414" height="548"/>
+                                <rect key="frame" x="0.0" y="167" width="414" height="549"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="blockLogCell" rowHeight="36" id="7rY-DO-9Xs" customClass="BlockLogCell" customModule="Lockdown" customModuleProvider="target">
@@ -170,14 +170,14 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3421" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sar-GU-wUS">
-                                <rect key="frame" x="139" y="138.33333333333334" width="41" height="22"/>
+                                <rect key="frame" x="128.66666666666666" y="138.33333333333334" width="40.333333333333343" height="21"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Bold" family="Montserrat" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                                 <size key="shadowOffset" width="0.0" height="0.0"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blocked today:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oYx-Wf-i0q">
-                                <rect key="frame" x="19" y="140.66666666666666" width="105" height="17.333333333333343"/>
+                                <rect key="frame" x="19.000000000000007" y="140.66666666666666" width="94.666666666666686" height="16.333333333333343"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -3638,6 +3638,7 @@
                     <navigationItem key="navigationItem" title="Account" id="Y6I-Ar-Q5y"/>
                     <connections>
                         <segue destination="FBF-Y3-Pii" kind="presentation" identifier="showWhatIsVPN" id="f2L-nH-Ive"/>
+                        <segue destination="uhi-Bj-03J" kind="presentation" identifier="showUpgradePlanAccount" id="qGh-4l-Gst"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="758-up-kc3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -3711,8 +3712,8 @@
         </designable>
     </designables>
     <inferredMetricsTieBreakers>
-        <segue reference="f2L-nH-Ive"/>
-        <segue reference="QzY-Hs-CoL"/>
+        <segue reference="bkM-ZW-kcf"/>
+        <segue reference="qGh-4l-Gst"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="blue_circle" width="104" height="104"/>

--- a/LockdowniOS/HomeViewController.swift
+++ b/LockdowniOS/HomeViewController.swift
@@ -851,10 +851,10 @@ class HomeViewController: BaseViewController, AwesomeSpotlightViewDelegate, Load
             if let vc = segue.destination as? SignupViewController {
                 if activePlans.isEmpty {
                     vc.mode = .newSubscription
-                    vc.enableVPNAfterSubscribe = false
+                    vc.enableVPNAfterSubscribe = true
                 } else {
                     vc.mode = .upgrade(active: activePlans)
-                    vc.enableVPNAfterSubscribe = false
+                    vc.enableVPNAfterSubscribe = true
                 }
             }
         default:

--- a/LockdowniOS/SignupViewController.swift
+++ b/LockdowniOS/SignupViewController.swift
@@ -15,6 +15,8 @@ class SignupViewController: BaseViewController {
 
     //MARK: - VARIABLES
     
+    var parentVC: UIViewController?
+    
     enum Mode {
         case newSubscription
         case upgrade(active: [Subscription.PlanType])
@@ -168,15 +170,12 @@ class SignupViewController: BaseViewController {
         toggleStartTrialButton(false)
         VPNSubscription.purchase (
             succeeded: {
-                let presentingViewController = self.presentingViewController as? HomeViewController
                 self.dismiss(animated: true, completion: {
+                    if let presentingViewController = self.parentVC as? AccountViewController {
+                        presentingViewController.reloadTable()
+                    }
                     if self.enableVPNAfterSubscribe {
-                        if presentingViewController != nil {
-                            presentingViewController?.toggleVPN("me")
-                        }
-                        else {
-                            VPNController.shared.setEnabled(true)
-                        }
+                        VPNController.shared.setEnabled(true)
                     }
                 })
             },


### PR DESCRIPTION
Related Changes:
- AccountVC - always reload on reloadTable, disregard isViewLoaded
- AccountVC - call new showUpgradePlanAccount segue
- ENHANCEMENT: "Cannot load your plan" -> Tappable "Error Loading Plan: Retry"
- FIX: Storyboard add segue from Account VC to SignUpVC
- Always enableVPNAfterSubscribe
- SignupViewController - call reloadTable if parentVC was AccountVC

Unrelated Changes:
- FIX: always request new receipt for SwiftyStoreKit
- VERSION: Bump build 4
- Remove MallocStackLogging on default build scheme

To Do: 
- FIX: Creating account or signing in after tutorial does not refresh account tab status